### PR TITLE
Small tweaks for ei-lectures

### DIFF
--- a/handler.php
+++ b/handler.php
@@ -22,14 +22,15 @@ class handler {
         $event->setDescription($summary . "\n" . $description);
         $event->setLocation($location);
 
-        //Remove the TAG and anything after e.g.: (IN0001)
-        $summary = preg_replace('/(\((IN|MA)[0-9]+,?\s?\)*).+/', '', $summary);
+        //Remove the TAG and anything after e.g.: (IN0001) or [MA0001]
+        $summary = preg_replace('/([\(\[](?:(?:IN|MA)\d+,?\s?)+[\)\]]).+/', '', $summary);
 
         //Some common replacements: yes its a long list
         $searchReplace = [];
         $searchReplace['Tutorübungen'] = 'TÜ';
         $searchReplace['Grundlagen'] = 'G';
         $searchReplace['Datenbanken'] = 'DB';
+        $searchReplace['Zentralübung'] = 'ZÜ';
         $searchReplace['Betriebssysteme und Systemsoftware'] = 'BS';
         $searchReplace['Einführung in die Informatik '] = 'INFO';
         $searchReplace['Praktikum: Grundlagen der Programmierung'] = 'PGP';
@@ -51,7 +52,7 @@ class handler {
         $summary = strtr($summary, $searchReplace);
 
         //Remove some stuff which is not really needed
-        $summary = str_replace(['Standardgruppe', 'PR, ', 'VO, ', 'FA, '], '', $summary);
+        $summary = str_replace(['Standardgruppe', 'PR, ', 'VO, ', 'FA, ', 'VI, ', 'TT, ', 'UE, '], '', $summary);
 
         //Try to make sense out of the location
         if (!empty($location)) {


### PR DESCRIPTION
- Updated TAG-regex to also remove square brackets e.g. [MA0012]
- Added acronym
- Updated list of _unnecessary stuff_

Regex should still match previous tag-patterns:
![screenshot_20171026_200723](https://user-images.githubusercontent.com/22451745/32069505-ab7fe238-ba89-11e7-8fc1-64fb1275c882.png)
