### PR TITLE
improve readme, add room numbers to location again (Google Maps will still work)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,8 @@ TumCalProxy [![Build Status](https://travis-ci.org/kordianbruck/TumCalProxy.svg)
 Proxy for the TUM iCal export to remove clutter from it and optimize the output
 
 You can find more information on the about page: https://cal.bruck.me/
+
+To run locally using docker:
+ - run `docker run --rm -it -v /ABSOLUTE/PATH/TO/PROJECT/:/app composer install` to install dependencies
+ - run `docker run --rm -it -v /ABSOLUTE/PATH/TO/PROJECT/:/app composer /app/vendor/bin/phpunit` to execute tests
+ - run `docker run --rm -p 80:80 -v /ABSOLUTE/PATH/TO/PROJECT/:/app webdevops/php-nginx:alpine` to run the webserver on port 80

--- a/handler.php
+++ b/handler.php
@@ -60,27 +60,28 @@ class handler {
 
         //Try to make sense out of the location
         if (!empty($location)) {
+            preg_match('/^(.*?,)/', $location, $matches);
             if (preg_match('/56\d{2}\.((EG)|\d{2})\.\d+/', $location)===1) {
                 // Informatik
-                self::switchLocation($event, $location, 'Boltzmannstraße 3, 85748 Garching bei München');
+                self::switchLocation($event, $location, $matches[1].' Boltzmannstraße 3, 85748 Garching bei München');
             } else if (preg_match('/55\d{2}\.((EG)|\d{2})\.\d+/', $location)===1) {
                 // Maschbau
-                self::switchLocation($event, $location, 'Boltzmannstraße 15, 85748 Garching bei München');
+                self::switchLocation($event, $location, $matches[1].' Boltzmannstraße 15, 85748 Garching bei München');
             } else if (preg_match('/8101\.((EG)|\d{2})\.\d+/', $location)===1) {
                 // Hochbrück - Physics
-                self::switchLocation($event, $location, 'Parkring 11-13, 85748 Garching bei München');
+                self::switchLocation($event, $location, $matches[1].' Parkring 11-13, 85748 Garching bei München');
             } else if (preg_match('/8102\.((EG)|\d{2})\.\d+/', $location)===1) {
                 // Hochbrück - Informatik
-                self::switchLocation($event, $location, 'Parkring 35-39, 85748 Garching bei München');
+                self::switchLocation($event, $location, $matches[1].' Parkring 35-39, 85748 Garching bei München');
             } else if (preg_match('/51\d{2}\.((EG)|\d{2})\.\d+/', $location)===1) {
                 // Physik
-                self::switchLocation($event, $location, 'James-Franck-Straße 1, 85748 Garching bei München');
+                self::switchLocation($event, $location, $matches[1].' James-Franck-Straße 1, 85748 Garching bei München');
             } else if (preg_match('/05\d{2}\.((EG)|\d{2})\.\d+/', $location)===1) {
                 // TUM Campus Innenstadt
-                self::switchLocation($event, $location, 'Arcisstraße 21, 80333 München');
+                self::switchLocation($event, $location, $matches[1].' Arcisstraße 21, 80333 München');
             } else if (preg_match('/01\d{2}\.((EG)|\d{2})\.\d+/', $location)===1) {
                 // TUM Innenstadt Nordbau
-                self::switchLocation($event, $location, 'Theresienstraße 90, 80333 München');
+                self::switchLocation($event, $location, $matches[1].' Theresienstraße 90, 80333 München');
             }
         }
 


### PR DESCRIPTION
Most calenders don't show the description in the preview, only the location. Therefore it's useful to have the room number in the location field too.

The commands added to the readme get the project going in seconds without needing anything installed except for Docker.